### PR TITLE
Feat: API 응답 형식 통일을 위한 api_response 함수 구현 및 커스텀 예외 처리 핸들러 추가

### DIFF
--- a/auth_server/auth_src/config/api_response.py
+++ b/auth_server/auth_src/config/api_response.py
@@ -1,0 +1,16 @@
+from rest_framework.response import Response
+from rest_framework import status
+
+
+def api_response(success=True, message="Success", data=None, errors=None, status_code=status.HTTP_200_OK):
+    response = {
+        "success": success,
+        "status": status_code,
+        "message": message,
+        "data": data if data is not None else [],
+    }
+
+    if errors:
+        response["errors"] = errors
+
+    return Response(response, status=status_code)

--- a/auth_server/auth_src/config/exceptions.py
+++ b/auth_server/auth_src/config/exceptions.py
@@ -1,0 +1,53 @@
+from rest_framework.views import exception_handler
+from rest_framework import status
+from config.api_response import api_response
+
+
+def custom_exception_handler(exc, context):
+    # 기본 예외 처리
+    response = exception_handler(exc, context)
+
+    if response is not None:
+        # 401 Unauthorized 처리
+        if response.status_code == 401:
+            return api_response(
+                success=False,
+                message="인증되지 않은 유저입니다.",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
+        # 400 Bad Request 처리
+        if response.status_code == 400:
+            return api_response(
+                success=False,
+                message="올바르지 않은 데이터입니다.",
+                errors=response.data,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        # 그 외의 일반적인 오류 처리
+        return api_response(
+            success=False,
+            message="예기치 않은 오류가 발생했습니다.",
+            errors=response.data,
+            status_code=response.status_code,
+        )
+
+    # 추가적인 예외 처리
+    if isinstance(exc, KeyError):
+        return api_response(
+            success=False,
+            message=f"필수 필드가 누락되었습니다. ({str(exc)})",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    elif isinstance(exc, ValueError):
+        return api_response(
+            success=False,
+            message=f"유효하지 않은 값입니다. ({str(exc)})",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # 기타 예외 처리
+    return api_response(
+        success=False,
+        message="요청을 처리할 수 없습니다. 나중에 다시 시도해 주세요.",
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )

--- a/auth_server/auth_src/config/settings.py
+++ b/auth_server/auth_src/config/settings.py
@@ -150,3 +150,7 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "EXCEPTION_HANDLER": "config.exceptions.custom_exception_handler",  # 에러 핸들러 설정
+}

--- a/auth_server/auth_src/pyproject.toml
+++ b/auth_server/auth_src/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120


### PR DESCRIPTION
## 작업 내용
- API 응답 형식 통일을 위한 api_response 함수 구현
- 커스텀 예외 처리 핸들러 추가

## 고민한 사항
- Response Formatting과 예외 처리를 어디에서 할 지 고민
- Response Formatting 및 예외 처리 방법
  - : API 응답 형식을 통일하고 에러 처리를 구조적으로 관리하기 위하여 미들웨어로 처리할지 함수로 처리할지에 대해 고민함.
  - 결정 사항: 미들웨어를 사용하지 않고, API 레벨에서 공통 함수와 커스텀 핸들러로 처리하는 방식을 선택함.
  - 이유: gRPC 통신 경로가 포함된 프로젝트 특성상, 미들웨어에서 처리할 경우 모든 통신 경로에 대해 예외 처리 로직을 추가해야 하는 등 코드 복잡도가 증가할 수 있음. 따라서 API 레벨에서 개별적으로 처리하는 것이 더 유연하며, REST API와 gRPC 통신의 특성에 맞게 각기 다른 에러 처리를 진행하고것이 효율적이라고 판단함.

## 기타
- pyproject.toml 파일을 추가하여 black의 기본 라인 길이를 88자에서 120자로 변경

## 관련 이슈
 - #11 
