### PR TITLE
Feat: 토큰 재발급 및 인증 API 구현

### DIFF
--- a/auth_server/auth_src/authentication/serializers/user_detail_serializer.py
+++ b/auth_server/auth_src/authentication/serializers/user_detail_serializer.py
@@ -13,4 +13,5 @@ class UserDetailSerializer(UserSerializer):
             "deleted_at",
             "is_active",
             "is_staff",
+            "is_superuser",
         ]

--- a/auth_server/auth_src/authentication/urls.py
+++ b/auth_server/auth_src/authentication/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 from authentication.views import LogoutAPIView, LoginAPIView, RegisterAPIView
+from rest_framework_simplejwt.views import TokenRefreshView
+
 
 app_name = "authentication"
 router = DefaultRouter()
@@ -9,6 +11,7 @@ urlpatterns = [
     path("login/", LoginAPIView.as_view(), name="login"),
     path("logout/", LogoutAPIView.as_view(), name="logout"),
     path("register/", RegisterAPIView.as_view(), name="register"),
+    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
 ]
 
 urlpatterns += router.urls

--- a/auth_server/auth_src/authentication/urls.py
+++ b/auth_server/auth_src/authentication/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
-from authentication.views import LogoutAPIView, LoginAPIView, RegisterAPIView
 from rest_framework_simplejwt.views import TokenRefreshView
+from authentication.views import LogoutAPIView, LoginAPIView, RegisterAPIView, TokenVerifyAPIView
 
 
 app_name = "authentication"
@@ -12,6 +12,7 @@ urlpatterns = [
     path("logout/", LogoutAPIView.as_view(), name="logout"),
     path("register/", RegisterAPIView.as_view(), name="register"),
     path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("token/verify/", TokenVerifyAPIView.as_view(), name="token_verify"),
 ]
 
 urlpatterns += router.urls

--- a/auth_server/auth_src/authentication/views/__init__.py
+++ b/auth_server/auth_src/authentication/views/__init__.py
@@ -1,3 +1,4 @@
 from .login_api_view import LoginAPIView
 from .logout_api_view import LogoutAPIView
 from .register_api_view import RegisterAPIView
+from .token_verify_api_view import TokenVerifyAPIView

--- a/auth_server/auth_src/authentication/views/token_verify_api_view.py
+++ b/auth_server/auth_src/authentication/views/token_verify_api_view.py
@@ -1,0 +1,41 @@
+from rest_framework_simplejwt.views import TokenVerifyView
+from rest_framework_simplejwt.tokens import AccessToken
+from rest_framework_simplejwt.exceptions import TokenError, InvalidToken
+from rest_framework.exceptions import ValidationError
+from rest_framework import status
+from django.shortcuts import get_object_or_404
+
+from authentication.serializers import UserDetailSerializer
+from config.api_response import api_response
+from authentication.models import User
+
+
+class TokenVerifyAPIView(TokenVerifyView):
+    def post(self, request, *args, **kwargs):
+        token = request.data.get("token")
+        if not token:
+            return api_response(
+                success=False, message="토큰이 제공되지 않았습니다.", status_code=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            access_token = AccessToken(token)
+            if access_token.get("token_type") != "access":
+                raise ValidationError("엑세스 토큰만 입력 가능합니다.")
+        except (InvalidToken, TokenError):
+            # 유효하지 않은 토큰 또는 만료된 토큰일 경우 처리
+            return api_response(
+                success=False,
+                message="유효하지 않은 토큰입니다. 다시 로그인하세요.",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
+        except ValidationError as e:
+            return api_response(success=False, message=str(e), status_code=status.HTTP_400_BAD_REQUEST)
+
+        user_id = access_token.get("user_id")
+        user = get_object_or_404(User, id=user_id)
+        serializer = UserDetailSerializer(user)
+
+        return api_response(
+            success=True, message="토큰 검증 성공하였습니다.", data=serializer.data, status_code=status.HTTP_200_OK
+        )


### PR DESCRIPTION
## 작업 내용
- Access Token 재발급 API (/auth/token/refresh/)
  - : Refresh Token을 이용하여 만료된 Access Token을 갱신
  - rest_framework_simplejwt 라이브러리의 TokenRefreshView를 활용하여 구현
- Access Token 인증 API (/auth/token/verify/):
  - 주어진 Access Token의 유효성을 검증하고, 유효할 경우 해당 사용자의 정보를 반환
  - 현재는 RESTful API로 구현되어 있으며, 추후 gRPC로 전환할 계획

## 고민한 점
- Access Token 재발급 API에서 토큰과 사용자 정보의 일치 여부 검증
  - rest_framework_simplejwt 라이브러리의 TokenRefreshView는 기본적으로 Refresh Token의 유효성만을 검증함
  - Refresh Token에 포함된 사용자 정보와 실제 API 요청을 한 사용자의 정보가 일치하는지 추가로 검증할 필요가 있는지 고민함
  - `Refresh Token`이 유효하다는 것은 해당 사용자가 이미 인증된 상태임을 의미하므로, 
  별도의 추가 검증을 하지 않는 것이 일반적이므로 구현하지 않음.

## 관련 이슈
- #10 
