### PR TITLE
Feat: 자원서버의 API 응답 형식 통일을 위한 api_response 함수 구현 및 커스텀 예외 처리 핸들러 추가

### DIFF
--- a/resource_server/resource_src/config/api_response.py
+++ b/resource_server/resource_src/config/api_response.py
@@ -1,0 +1,16 @@
+from rest_framework.response import Response
+from rest_framework import status
+
+
+def api_response(success=True, message="Success", data=None, errors=None, status_code=status.HTTP_200_OK):
+    response = {
+        "success": success,
+        "status": status_code,
+        "message": message,
+        "data": data if data is not None else [],
+    }
+
+    if errors:
+        response["errors"] = errors
+
+    return Response(response, status=status_code)

--- a/resource_server/resource_src/config/exceptions.py
+++ b/resource_server/resource_src/config/exceptions.py
@@ -1,0 +1,53 @@
+from rest_framework.views import exception_handler
+from rest_framework import status
+from config.api_response import api_response
+
+
+def custom_exception_handler(exc, context):
+    # 기본 예외 처리
+    response = exception_handler(exc, context)
+
+    if response is not None:
+        # 401 Unauthorized 처리
+        if response.status_code == 401:
+            return api_response(
+                success=False,
+                message="인증되지 않은 유저입니다.",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
+        # 400 Bad Request 처리
+        if response.status_code == 400:
+            return api_response(
+                success=False,
+                message="올바르지 않은 데이터입니다.",
+                errors=response.data,
+                status_code=status.HTTP_400_BAD_REQUEST,
+            )
+        # 그 외의 일반적인 오류 처리
+        return api_response(
+            success=False,
+            message="예기치 않은 오류가 발생했습니다.",
+            errors=response.data,
+            status_code=response.status_code,
+        )
+
+    # 추가적인 예외 처리
+    if isinstance(exc, KeyError):
+        return api_response(
+            success=False,
+            message=f"필수 필드가 누락되었습니다. ({str(exc)})",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    elif isinstance(exc, ValueError):
+        return api_response(
+            success=False,
+            message=f"유효하지 않은 값입니다. ({str(exc)})",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # 기타 예외 처리
+    return api_response(
+        success=False,
+        message="요청을 처리할 수 없습니다. 나중에 다시 시도해 주세요.",
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )

--- a/resource_server/resource_src/config/settings.py
+++ b/resource_server/resource_src/config/settings.py
@@ -147,3 +147,7 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    "EXCEPTION_HANDLER": "config.exceptions.custom_exception_handler",  # 에러 핸들러 설정
+}

--- a/resource_server/resource_src/pyproject.toml
+++ b/resource_server/resource_src/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120


### PR DESCRIPTION
## 작업 내용
- API 응답 형식 통일을 위한 api_response 함수 구현
- 커스텀 예외 처리 핸들러 추가

## 고민한 사항
- 현재 구현한 커스텀 예외 처리 핸들러가 최선인가? 

## 관련 작업
- 인증서버의 API 응답 형식 통일을 위한 api_response 함수 구현 및 커스텀 예외 처리 핸들러 추가
- : #12 

## 관련 이슈
- #22 